### PR TITLE
fix: verify full bill across quorum and tighten docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 v0.0.3
 
 ## Abstract
-QMoney introduces a novel quantum money system that combines the unforgeable nature of quantum states with a peer-to-peer (P2P) transaction framework inspired by Bitcoin. Using a 2-qubit quantum bill, QMoney leverages the **no-cloning theorem** to ensure that currency cannot be counterfeited, while a decentralized network of nodes verifies and transfers ownership without a central mint or bank. This white paper details the preparation, verification, and P2P exchange of quantum bills, illustrated through a toy example using photon polarization and polarizers. By merging quantum security with Bitcoin’s P2P philosophy, QMoney offers a vision for a trustless, quantum-secure digital currency.
+QMoney introduces a novel quantum money system that combines the unforgeable nature of quantum states with a peer-to-peer (P2P) transaction framework inspired by Bitcoin. Using a 2-qubit quantum bill, QMoney leverages the **no-cloning theorem** to ensure that currency cannot be counterfeited, while a decentralized network of nodes verifies and transfers ownership without a central mint or bank. More precisely, the construction in this repository is a **quorum-verified, private-key quantum cash design with verify-and-remint**, rather than a non-interactive public-key quantum money scheme. This white paper details the preparation, verification, and P2P exchange of quantum bills, illustrated through a toy example using photon polarization. By merging quantum security with Bitcoin’s P2P philosophy, QMoney offers a vision for a trustless, quantum-secure digital currency.
 
 ---
 
@@ -60,7 +60,8 @@ For QMoney, a workable “public verification” interpretation is:
 - Anyone can request verification from the network.
 - A consensus mechanism (PoW/PoS/permissioned membership) selects a **verifier committee/quorum** (Sybil resistance happens at the committee-selection layer).
 - The quorum collectively holds the bill’s secret measurement data (bases/bits), replicated or threshold-shared.
-- The quorum measures the bill and signs an **accept/reject attestation** that the rest of the network validates classically.
+- All qubits are measured across the participating quorum members before an accept/reject result is produced.
+- The quorum signs an **accept/reject attestation** that the rest of the network validates classically.
 
 Appendix A specifies a simplest quorum-based “verify-and-remint” flow that scales to 512/1024 qubits in a pure software simulator.
 
@@ -84,7 +85,7 @@ QMoney’s security combines quantum and P2P strengths:
 
 ## 4. Simulating QMoney
 ### 4.1 Software Simulator (Statevector/MPS)
-For a practical toy implementation today, simulation is easiest in software. Appendix A (and `qmoney_mps_quorum_demo.py`) describes a quorum-verified design where each bill is a BB84 product state that can be represented as an MPS with bond dimension `D=1`, enabling 512/1024-qubit bills on consumer hardware.
+For a practical toy implementation today, simulation is easiest in software. Appendix A (and `qmoney_mps_quorum_demo.py`) describes a quorum-verified design where each bill is a BB84 product state that can be represented as an MPS with bond dimension `D=1`, enabling 512/1024-qubit bills on consumer hardware. On the same classical machines, straightforward **state-vector simulation** is already practical for roughly **30–32 logical qubits**, while **matrix-product-state / tensor-network** methods extend much farther for these low-entanglement product-state bills.
 
 ### 4.2 Setup
 We simulate a QMoney bill using photon polarization:
@@ -189,7 +190,8 @@ This state is a tensor product of single-qubit states, so it is an MPS with **bo
    - It checks outcomes against `V` with an acceptance rule (exact match, or thresholded for noise).
 4. **Ledger update (atomic)**:
    - If accepted: mark `old_serial` spent; set ownership of a newly minted bill to `receiver_pk`.
-   - If rejected: mark `old_serial` invalid/spent (the state was consumed by measurement anyway).
+   - If rejected after measurement: mark `old_serial` invalid/spent (the state was consumed by measurement anyway).
+   - If a quorum cannot be assembled before verification starts, leave `old_serial` live and abort without consuming the bill.
 5. **Re-mint**: quorum generates fresh `(new_serial, B', V')` and prepares a new `n`-qubit product state for the receiver.
 
 This is “one-time spend” at the quantum layer, but supports repeated circulation via re-minting.
@@ -204,6 +206,7 @@ Implementation notes:
 - Applying a single-qubit unitary is a `2x2` multiply on the physical index of `A[i]`.
 - Z-basis measurement samples probabilities from the local 2-vector and collapses it to `|0⟩` or `|1⟩`.
 - For `n=1024`, this remains linear-time and linear-memory in `n` as long as you do not introduce entangling gates (bond dimension stays 1).
+- As a practical rule of thumb on current classical hardware, brute-force state-vector simulation is typically comfortable up to about `30–32` logical qubits, after which tensor-network / MPS methods become the natural route for this low-entanglement construction.
 
 ### A.6 Security level (toy intercept/resend counterfeiter)
 In the simplest threat model where a counterfeiter must produce a state that passes verification without knowing `B`, a per-qubit basis guess succeeds with probability `3/4`. If the quorum checks all qubits with exact matching:

--- a/qmoney_mps_quorum_demo.py
+++ b/qmoney_mps_quorum_demo.py
@@ -188,21 +188,20 @@ class QuorumService:
 
         rng = random.Random(seed)
 
-        # Partition indices across nodes to reflect distributed measurement.
-        n_nodes = len(self.nodes)
-        assignments: List[List[int]] = [[] for _ in range(n_nodes)]
-        for i in range(bill.n):
-            assignments[i % n_nodes].append(i)
+        participants = [node for node in self.nodes if node.has_secret(bill.serial)]
 
-        approvals = 0
+        # If we cannot assemble a quorum, verification never starts and the bill remains live.
+        if len(participants) < self.threshold:
+            return False, None
+
+        # Partition indices across participating nodes so the whole bill is checked.
+        assignments: List[List[int]] = [[] for _ in range(len(participants))]
+        for i in range(bill.n):
+            assignments[i % len(participants)].append(i)
+
         matches_total = 0
         measured_total = 0
-        for node_idx, node in enumerate(self.nodes):
-            if approvals >= self.threshold:
-                break
-            if not node.has_secret(bill.serial):
-                continue
-
+        for node_idx, node in enumerate(participants):
             # Each node gets an independent RNG stream.
             node_rng = random.Random(rng.getrandbits(64) ^ (node_idx << 32) ^ node.node_id)
             matches, measured = node.verify_indices(
@@ -213,12 +212,6 @@ class QuorumService:
             )
             matches_total += matches
             measured_total += measured
-            approvals += 1
-
-        # If we didn't reach threshold, treat as verification failure.
-        if approvals < self.threshold:
-            ledger.mark_spent(bill.serial)
-            return False, None
 
         # Bill was consumed by measurement; spend it regardless of outcome.
         ledger.mark_spent(bill.serial)

--- a/tests/test_qmoney.py
+++ b/tests/test_qmoney.py
@@ -1,0 +1,60 @@
+import unittest
+from types import MethodType
+
+from qmoney_mps_quorum_demo import Ledger, QuorumNode, QuorumService
+
+
+class QuorumVerificationTests(unittest.TestCase):
+    def test_verify_and_remint_measures_all_qubits_even_when_threshold_is_lower_than_node_count(self):
+        nodes = [QuorumNode(i) for i in range(4)]
+        quorum = QuorumService(nodes, threshold=3)
+        ledger = Ledger()
+        bill = quorum.mint_bill(8, owner="alice", ledger=ledger)
+
+        calls = []
+
+        def recording_verify(self, bill, indices, *, noise_bitflip_p, rng):
+            calls.append((self.node_id, tuple(indices)))
+            return len(indices), len(indices)
+
+        for node in nodes:
+            node.verify_indices = MethodType(recording_verify, node)
+
+        accepted, new_bill = quorum.verify_and_remint(
+            bill,
+            claimant="alice",
+            receiver="bob",
+            ledger=ledger,
+            seed=123,
+        )
+
+        self.assertTrue(accepted)
+        self.assertIsNotNone(new_bill)
+        self.assertCountEqual([node_id for node_id, _ in calls], [0, 1, 2, 3])
+        measured_indices = [idx for _, indices in calls for idx in indices]
+        self.assertEqual(sorted(measured_indices), list(range(8)))
+
+    def test_verify_and_remint_does_not_spend_bill_when_not_enough_verifiers_are_available(self):
+        nodes = [QuorumNode(i) for i in range(4)]
+        quorum = QuorumService(nodes, threshold=4)
+        ledger = Ledger()
+        bill = quorum.mint_bill(8, owner="alice", ledger=ledger)
+
+        nodes[-1]._secrets.pop(bill.serial)
+
+        accepted, new_bill = quorum.verify_and_remint(
+            bill,
+            claimant="alice",
+            receiver="bob",
+            ledger=ledger,
+            seed=123,
+        )
+
+        self.assertFalse(accepted)
+        self.assertIsNone(new_bill)
+        self.assertFalse(ledger.is_spent(bill.serial))
+        self.assertEqual(ledger.owner_of(bill.serial), "alice")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- measure all qubits across participating quorum members
- keep bills live when a quorum cannot be assembled
- add regression tests for quorum verification semantics
- document state-vector vs MPS simulator guidance