### PR TITLE
docs: reframe QMoney README around Wiesner, Shor, and Aaronson

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ not near-term deployment of production quantum money.
 
 ### Architecture
 - [`docs/architecture/public-vs-private-key-qmoney.md`](docs/architecture/public-vs-private-key-qmoney.md) — canonical statement of the current repo architecture and why QMoney is private-key quantum cash rather than public-key quantum money.
+- [`docs/architecture/software-mps-quorum-design.md`](docs/architecture/software-mps-quorum-design.md) — preserved technical appendix for the current software-only MPS/quorum baseline, including data model, protocol flow, simulation assumptions, and security intuition.
 
 ### Research notes
 - [`docs/research/shor-arguments-and-qmoney-integration.md`](docs/research/shor-arguments-and-qmoney-integration.md) — how Peter Shor’s arguments should shape QMoney’s architecture split, terminology, and public-key research boundaries.

--- a/README.md
+++ b/README.md
@@ -1,251 +1,180 @@
-# QMoney: A Peer-to-Peer Quantum Money System
+# QMoney
 
-v0.0.3
+QMoney is a research repo for **distributed private-key quantum cash** inspired by:
 
-## Abstract
-QMoney introduces a novel quantum money system that combines the unforgeable nature of quantum states with a peer-to-peer (P2P) transaction framework inspired by Bitcoin. Using a 2-qubit quantum bill, QMoney leverages the **no-cloning theorem** to ensure that currency cannot be counterfeited, while a decentralized network of nodes verifies and transfers ownership without a central mint or bank. More precisely, the construction in this repository is a **quorum-verified, private-key quantum cash design with verify-and-remint**, rather than a non-interactive public-key quantum money scheme. This white paper details the preparation, verification, and P2P exchange of quantum bills, illustrated through a toy example using photon polarization. By merging quantum security with Bitcoin’s P2P philosophy, QMoney offers a vision for a trustless, quantum-secure digital currency.
+- **Wiesner / Shor quantum money ideas**: unclonable quantum states, hidden verification data, and the distinction between private-key and public-key quantum money
+- **Aaronson / Christiano private-key quantum money ideas**: adaptive-query security, compact-secret tradeoffs, mini-scheme vs full-scheme thinking, and the importance of rigorous verifier models
+- **Bitcoin-style system design**: public ownership, signed transfer intent, distributed validation, and ledger finality
 
----
+The core idea is simple:
 
-## 1. Introduction
-Traditional currencies and even modern cryptocurrencies like Bitcoin face challenges in achieving absolute unforgeability. Physical money can be replicated with advanced techniques, while Bitcoin, though secure against double-spending via its blockchain, relies on computational assumptions vulnerable to quantum attacks (e.g., Shor’s algorithm breaking ECDSA). Quantum money, first proposed by Stephen Wiesner in 1969, encodes currency in quantum states—such as superpositions of qubits—that cannot be perfectly copied due to the **no-cloning theorem**, offering a physics-based solution to counterfeiting.
+> use **no-cloning** for the quantum anti-counterfeiting layer, and use a **Bitcoin-like classical settlement layer** for ownership transfer, attestations, and spent-state tracking.
 
-**QMoney** extends this concept into a **peer-to-peer quantum money system**, integrating Bitcoin’s decentralized ethos. In Bitcoin, a P2P network of nodes validates transactions without a central authority, using a public ledger (the blockchain) to track ownership. QMoney adapts this model: instead of a mint and bank, users and nodes in a network collectively issue, verify, and transfer 2-qubit quantum bills. This white paper presents a minimal 2-qubit scheme to illustrate QMoney’s core mechanisms—quantum state preparation, decentralized verification, and P2P exchange—while providing a practical example with photon polarization. As of March 2025, quantum hardware remains experimental, but QMoney lays a theoretical foundation for a future where quantum and P2P technologies converge.
-
-### Key architecture references
-- [`docs/architecture/public-vs-private-key-qmoney.md`](docs/architecture/public-vs-private-key-qmoney.md) — canonical statement of the current repo architecture: QMoney today is private-key quantum cash at the quantum layer, with a classical public-key ownership/settlement layer.
-- [`docs/research/shor-arguments-and-qmoney-integration.md`](docs/research/shor-arguments-and-qmoney-integration.md) — key reference explaining Peter Shor’s arguments about quantum money and how they should shape QMoney’s terminology, architecture split, and future public-key research track.
-- [`docs/research/aaronson-private-key-quantum-money-and-qmoney.md`](docs/research/aaronson-private-key-quantum-money-and-qmoney.md) — key reference grounded in Aaronson’s QCrypt private-key quantum money talk and related papers, focusing on adaptive-query security, compact-secret tradeoffs, and why QMoney fits the distributed private-key quantum cash lineage.
+The current repo does **not** implement true public-key quantum money. It implements a **quorum-verified, private-key quantum cash** model with **verify-and-remint** semantics.
 
 ---
 
-## 2. Theoretical Background
-### 2.1 The No-Cloning Theorem
-The **no-cloning theorem**, established by Wootters and Zurek in 1982, underpins QMoney’s security. It asserts that there is no physical process (no unitary) that can take an unknown quantum state `|ψ⟩ = α|0⟩ + β|1⟩` and produce a perfect copy `|ψ⟩ ⊗ |ψ⟩` for all possible `α,β`.
+## What QMoney currently is
 
-Attempts to copy an unknown state (e.g., by measuring and reconstructing) generally disturb it: measuring in the wrong basis collapses superposition information (e.g., `|+⟩` becomes `|0⟩` or `|1⟩`). In QMoney, this disturbance is the anti-counterfeiting signal.
+QMoney today is best described as:
 
-### 2.2 Qubits and Measurement Bases
-A **qubit**, unlike Bitcoin’s classical bits, exists in a superposition within a two-dimensional Hilbert space:
-- `|0⟩` and `|1⟩` (computational / Z basis);
-- `|+⟩ = (|0⟩ + |1⟩)/√2` and `|−⟩ = (|0⟩ − |1⟩)/√2` (Hadamard / X basis).
+- **private-key quantum cash** at the quantum layer
+- **quorum-verified** rather than universally self-verifiable
+- **verify-and-remint** rather than “verify the same note forever”
+- **classical public-key settlement** at the ownership / ledger layer
 
-Measurement occurs in bases:
-- **Standard (Z) basis**: `|0⟩`, `|1⟩`;
-- **Hadamard (X) basis**: `|+⟩`, `|−⟩`, which can be implemented as “apply Hadamard then measure in Z”, where `H = (1/√2) * [[1, 1], [1, -1]]`.
+In the current simulator family, a bill is a BB84-style product state with hidden per-qubit verification data. A verifier quorum holds the secret measurement information, checks the note, consumes it by measurement, and if valid re-mints a fresh note for the recipient.
 
-QMoney uses these bases to encode bills, with verification performed by P2P nodes rather than a central authority, mirroring Bitcoin’s distributed validation.
-
-### 2.3 Bitcoin’s Peer-to-Peer Model
-Bitcoin operates on a P2P network where nodes (computers running the Bitcoin protocol) validate transactions using a proof-of-work consensus mechanism. Transactions are broadcast to the network, recorded on a blockchain, and verified without intermediaries.
-
-QMoney adopts this P2P structure, but must account for a key difference: quantum states are not copyable, and verification consumes the state. This makes “broadcast the bill to every node and let everyone verify” incompatible with no-cloning.
+That means:
+- the note family is **Wiesner-like / private-key** in structure
+- the system-level circulation model is **distributed and Bitcoin-inspired**
+- the public-facing part is the **classical ledger/attestation layer**, not a public quantum verifier
 
 ---
 
-## 3. QMoney: 2-Qubit Peer-to-Peer Quantum Money Scheme
-### 3.1 State Preparation
-In QMoney, a 2-qubit quantum bill is created by any user (a “minter”) in the P2P network:
-1. **Random Basis Selection**: For each qubit, choose:
-   - 0 (standard basis: |0⟩, |1⟩), 50% probability;
-   - 1 (Hadamard basis: |+⟩, |-⟩), 50% probability.
-2. **Random Bit Value**: 0 or 1, 50% probability.
-3. **State Preparation**:
-   - Basis 0, bit 0: |0⟩;
-   - Basis 0, bit 1: |1⟩;
-   - Basis 1, bit 0: |+⟩;
-   - Basis 1, bit 1: |-⟩.
+## Why this framing matters
 
-The minter assigns a classical `serial` and prepares the quantum state (e.g., `|0⟩ ⊗ |−⟩`). For a decentralized system, the secret basis/bit data used for verification should not be broadcast in plaintext; it must be held by a verifier set (replicated or threshold-shared) together with a public commitment (see Appendix A).
+The research in this repo is organized around a distinction that Shor and Aaronson both make clear:
 
-### 3.2 Verification
-Verification is decentralized, but a quantum system has a constraint that Bitcoin does not: **the same quantum state cannot be independently checked by many nodes without consuming it**.
+### Private-key quantum money / cash
+- valid verification depends on hidden note information
+- verifier interaction is a major attack surface
+- repeated-query / adaptive attacks matter
+- compact verifier secrets often introduce computational assumptions
 
-For QMoney, a workable “public verification” interpretation is:
-- Anyone can request verification from the network.
-- A consensus mechanism (PoW/PoS/permissioned membership) selects a **verifier committee/quorum** (Sybil resistance happens at the committee-selection layer).
-- The quorum collectively holds the bill’s secret measurement data (bases/bits), replicated or threshold-shared.
-- All qubits are measured across the participating quorum members before an accept/reject result is produced.
-- The quorum signs an **accept/reject attestation** that the rest of the network validates classically.
+### Public-key quantum money
+- anyone can verify from public information
+- verification must not reveal how to mint valid notes
+- requires a different note family and a different security story
 
-Appendix A specifies a simplest quorum-based “verify-and-remint” flow that scales to 512/1024 qubits in a pure software simulator.
-
-### 3.3 Peer-to-Peer Transfer
-To spend a bill, the owner transfers the quantum state to the selected verifier quorum along with a signed transaction naming the intended recipient. The quorum verifies the state (consuming it by measurement) and, if valid, the network finalizes an ownership update.
-
-**Quantum-aware blockchain (minimal definition):** a classical ledger that stores only classical metadata, e.g.:
-- `serial`, a commitment to verification data, and current `owner_pk`;
-- a spent flag / status;
-- the verifier quorum’s signed attestation for the verification event.
-
-The ledger does not store the quantum state; it stores public evidence that a specific serial was consumed in a verified spend. Double-spending is prevented by standard ledger finality rules (e.g., BFT finality or Nakamoto-style confirmation), not by re-checking the quantum state.
-
-### 3.4 Security
-QMoney’s security combines quantum and P2P strengths:
-- **No-Cloning**: Prevents state duplication.
-- **Secret Verification Data**: Bases/bits are kept from adversaries (e.g., held by a verifier quorum rather than published).
-- **Consensus Finality**: A classical consensus protocol prevents replay/double-spend of a serial once verification consumes the bill.
+QMoney’s current baseline is in the **private-key** camp.
 
 ---
 
-## 4. Simulating QMoney
-### 4.1 Software Simulator (Statevector/MPS)
-For a practical toy implementation today, simulation is easiest in software. Appendix A (and `qmoney_mps_quorum_demo.py`) describes a quorum-verified design where each bill is a BB84 product state that can be represented as an MPS with bond dimension `D=1`, enabling 512/1024-qubit bills on consumer hardware. On the same classical machines, straightforward **state-vector simulation** is already practical for roughly **30–32 logical qubits**, while **matrix-product-state / tensor-network** methods extend much farther for these low-entanglement product-state bills.
+## Current architecture
 
-### 4.2 Setup
-We simulate a QMoney bill using photon polarization:
-- |0⟩: Horizontal (H);
-- |1⟩: Vertical (V);
-- |+⟩: Diagonal (D);
-- |-⟩: Anti-diagonal (A).
-- **Hadamard Simulation**: Half-wave plate (HWP) at 22.5°.
+QMoney has two layers.
 
-Nodes use polarizers and HWPs to verify states in a P2P setting.
+### 1. Quantum note layer
+- BB84-style note family
+- hidden basis / outcome data
+- consumptive verification
+- no-cloning as the anti-counterfeiting primitive
 
-### 4.3 Example QMoney Bill
-A user prepares:
-- **Qubit 0**: Basis 0, bit 0 → |0⟩ (H);
-- **Qubit 1**: Basis 1, bit 1 → |-⟩ (A).
+### 2. Classical settlement layer
+- owner public keys
+- signed transfer intent
+- quorum attestations
+- spent-state tracking
+- ledger finality
 
-State: |0⟩ ⊗ |-⟩ (H ⊗ A). Serial number (“0:0, 1:1”) is encrypted and broadcast.
-
-### 4.4 Verification Process
-Nodes in the P2P network:
-- **Qubit 0**: Measure with H polarizer → Passes, yields |0⟩.
-- **Qubit 1**: Apply HWP (A → V), measure with V polarizer → Passes, yields |1⟩.
-
-Results (‘10’) are broadcast; majority consensus confirms validity.
-
-### 4.5 Simulating a Counterfeiting Attempt
-An adversary measures in the standard basis:
-- Qubit 0 (H): H → |0⟩;
-- Qubit 1 (A): H or V (50% each), e.g., V.
-
-Prepares H ⊗ V copies. Nodes verify:
-- Qubit 0: Passes;
-- Qubit 1: HWP (V → A), V polarizer → 50% pass rate.
-
-Copies fail consensus 50% of the time, detected by the network.
+This split is intentional. Classical public-key cryptography helps handle ownership and settlement, but it does **not** turn the quantum note family into public-key quantum money.
 
 ---
 
-## 5. Security Analysis
-QMoney’s dual-layer security includes:
-- **Quantum Protection**: No-cloning ensures unforgeability.
-- **P2P Resilience**: Decentralized nodes prevent single-point failures, unlike Bitcoin’s reliance on computational puzzles vulnerable to quantum speedup.
-- **Error Detection**: Wrong-basis measurements yield inconsistent results across nodes.
+## Verify-and-remint model
 
-For two qubits, counterfeiting success drops to 25% with one Hadamard-basis qubit; more qubits amplify this exponentially.
+The current QMoney model is:
 
----
+1. A sender presents a quantum note plus a classical transfer intent.
+2. A verifier quorum measures the note using hidden verification data.
+3. The note is consumed by measurement.
+4. If valid, the quorum attests acceptance and prepares a fresh note for the recipient.
+5. The classical ledger marks the old serial spent and records the new owner / note state.
 
-## 6. Challenges and Limitations
-- **Security Scaling**: Two qubits are only pedagogical; practical counterfeit probabilities require hundreds to thousands of qubits depending on the verification rule and noise tolerance (Appendix A gives concrete scaling for BB84-style verification).
-- **Noise vs Counterfeit**: Real channels introduce loss and bit/phase errors; verification must be thresholded and parameterized so honest bills pass with high probability while forgeries remain unlikely.
-- **State Transfer Practicality**: Moving quantum states between peers requires quantum networking primitives; in practice, verification will likely be “online” and localized (committee/quorum) rather than “every node measures the bill”.
-- **Sybil Resistance / Committee Selection**: A P2P verification story must specify how verifier committees are chosen (PoW/PoS/permissioned membership) and how equivocation is handled.
-- **Issuance / Supply Policy**: If “anyone can mint,” supply is unbounded; a realistic design needs an issuance rule (e.g., a Nakamoto-style schedule, or minting only as part of verify-and-remint so total supply is conserved).
-- **Hybrid Security**: Even with quantum anti-counterfeiting, the system still relies on classical cryptography for identities, commitments, and ledger consensus.
+This is closer to **distributed private-key quantum cash** than to a self-verifying public token.
 
 ---
 
-## 7. Conclusion
-QMoney fuses quantum unforgeability with Bitcoin’s P2P framework, offering a trustless, quantum-secure currency. This 2-qubit model, demonstrated with polarizers, showcases its potential. Future work could scale QMoney with advanced quantum networks and ledgers, heralding a new era of decentralized finance.
+## Why Bitcoin is relevant here
+
+Bitcoin matters to QMoney not because Bitcoin already solves quantum money, but because it contributes the **system architecture**:
+
+- distributed validation
+- signed transactions
+- public ownership tracking
+- ledger finality
+- no reliance on a single monolithic bank server
+
+QMoney tries to combine that system architecture with a quantum anti-counterfeiting primitive. The result is not “quantum Bitcoin,” but a hybrid design:
+
+- **quantum** for unclonable notes
+- **classical distributed systems** for circulation and settlement
 
 ---
 
-## Appendix A: 512/1024-Qubit QMoney in a Pure Software Simulator (Quorum Public Verification + MPS)
-This appendix describes a simplest-possible path to **512 or 1024 qubits** that:
-- Supports **public verification** in the sense that *anyone can request verification from the network*;
-- Avoids exotic public-key quantum money constructions;
-- Runs on consumer hardware by keeping the bill state **very low entanglement** (product-state MPS with bond dimension D=1).
+## What this repo is for
 
-### A.1 Design choice: verification by a quorum (not by the bill holder)
-The simplest way to get “public verification” while keeping the quantum state easy (MPS-friendly) is to make verification an **online service provided by a verifier quorum**:
-- A verifier quorum collectively holds the bill’s secret measurement data (bases/bits).
-- The bill holder never learns the full secret.
-- Verification **consumes** the presented quantum state.
-- If valid, the quorum **re-mints a fresh bill** for the recipient (new serial, new secret, new quantum state).
+This repo is a research and simulation workspace for:
 
-This keeps the quantum component “unforgeable by physics” (no-cloning), while the “public” property comes from decentralized access (anyone can ask), not from non-interactive public verifiability.
+- honest framing of private-key vs public-key quantum money
+- quorum-based private-key quantum cash architectures
+- verify-and-remint transfer flows
+- software simulation of BB84-style note families
+- future public-key quantum money research tracks kept separate from the current baseline
 
-### A.2 Data model (one bill)
-For a bill with `n ∈ {512, 1024}` qubits:
-- `serial`: unique identifier (e.g., 128-bit random).
-- `owner_pk`: current owner public key (ledger field).
-- `C`: public commitment (e.g., `C = H(serial || B || V || nonce)`).
-- Secret strings (known only to the verifier quorum):
-  - `B ∈ {0,1}^n` where `B[i]=0` means Z-basis, `B[i]=1` means X-basis.
-  - `V ∈ {0,1}^n` target outcomes in that basis.
+Near-term value here is primarily:
+- conceptual clarity
+- simulator design
+- attack modeling
+- note-family comparison
+- architecture documentation
 
-### A.3 Quantum state preparation (BB84 product state)
-Each qubit `i` is prepared as:
-- If `B[i]=0` and `V[i]=0`: `|0⟩`
-- If `B[i]=0` and `V[i]=1`: `|1⟩`
-- If `B[i]=1` and `V[i]=0`: `|+⟩`
-- If `B[i]=1` and `V[i]=1`: `|−⟩`
+not near-term deployment of production quantum money.
 
-This state is a tensor product of single-qubit states, so it is an MPS with **bond dimension D=1**.
+---
 
-### A.4 Public verification + transfer protocol (verify-and-remint)
-1. **Transfer intent**: sender creates a classical transaction `tx` naming `(old_serial, receiver_pk, fee, ...)` and signs it.
-2. **Present bill**: sender submits the bill’s quantum state plus `tx` to a verifier quorum (in software, this can be passing an object/handle).
-3. **Quorum verification**:
-   - The quorum measures the submitted state in the secret bases `B`.
-   - It checks outcomes against `V` with an acceptance rule (exact match, or thresholded for noise).
-4. **Ledger update (atomic)**:
-   - If accepted: mark `old_serial` spent; set ownership of a newly minted bill to `receiver_pk`.
-   - If rejected after measurement: mark `old_serial` invalid/spent (the state was consumed by measurement anyway).
-   - If a quorum cannot be assembled before verification starts, leave `old_serial` live and abort without consuming the bill.
-5. **Re-mint**: quorum generates fresh `(new_serial, B', V')` and prepares a new `n`-qubit product state for the receiver.
+## Key references in this repo
 
-This is “one-time spend” at the quantum layer, but supports repeated circulation via re-minting.
+### Architecture
+- [`docs/architecture/public-vs-private-key-qmoney.md`](docs/architecture/public-vs-private-key-qmoney.md) — canonical statement of the current repo architecture and why QMoney is private-key quantum cash rather than public-key quantum money.
 
-### A.5 MPS simulation requirements (consumer hardware)
-For this BB84 product-state design, you only need:
-- Single-qubit gates: Hadamard `H` (to implement X-basis measurement as `H` then Z-measure).
-- Projective measurement with collapse.
+### Research notes
+- [`docs/research/shor-arguments-and-qmoney-integration.md`](docs/research/shor-arguments-and-qmoney-integration.md) — how Peter Shor’s arguments should shape QMoney’s architecture split, terminology, and public-key research boundaries.
+- [`docs/research/aaronson-private-key-quantum-money-and-qmoney.md`](docs/research/aaronson-private-key-quantum-money-and-qmoney.md) — transcript-backed note on Aaronson’s private-key quantum money ideas, adaptive-query security, compact-secret tradeoffs, and why QMoney fits the distributed private-key lineage.
 
-Implementation notes:
-- Represent the bill as an MPS with tensors `A[i]` of shape `(1, 2, 1)`.
-- Applying a single-qubit unitary is a `2x2` multiply on the physical index of `A[i]`.
-- Z-basis measurement samples probabilities from the local 2-vector and collapses it to `|0⟩` or `|1⟩`.
-- For `n=1024`, this remains linear-time and linear-memory in `n` as long as you do not introduce entangling gates (bond dimension stays 1).
-- As a practical rule of thumb on current classical hardware, brute-force state-vector simulation is typically comfortable up to about `30–32` logical qubits, after which tensor-network / MPS methods become the natural route for this low-entanglement construction.
+---
 
-### A.6 Security level (toy intercept/resend counterfeiter)
-In the simplest threat model where a counterfeiter must produce a state that passes verification without knowing `B`, a per-qubit basis guess succeeds with probability `3/4`. If the quorum checks all qubits with exact matching:
-- Forgery success: `P_forge = (3/4)^n`
-- Security bits: `s = -log2(P_forge) = n * log2(4/3) ≈ 0.415 * n`
+## Current simulator / demo
 
-So:
-- `n=512`: `s ≈ 212.5` bits (`P_forge ≈ 2^-212.5`)
-- `n=1024`: `s ≈ 425.0` bits (`P_forge ≈ 2^-425`)
-
-If you allow up to `t` mismatches for noise, replace the exact-match probability with a binomial tail `Pr[Binomial(n, 3/4) ≥ n - t]`, which increases attacker success; choose `t` based on your simulated noise model.
-
-### A.7 Suggested parameters (software-only v0)
-- Qubits per bill: `n=1024` (or `n=512` for faster iteration).
-- Verification: measure all `n` qubits; accept if `matches ≥ n - t`.
-- Noise tolerance: start with `t=0` (no noise) and later try `t = floor(0.01 * n)` in a noisy simulator.
-- Verifier quorum: `N = 3f + 1` nodes; require `2f + 1` signed approvals to finalize “accepted + reminted” on the ledger.
-- Secret storage: for a toy, replicate `(B,V)` across the quorum; for stronger fault tolerance, store `B` and `V` via threshold secret sharing.
-
-## 8. Citations
-- Nakamoto, S. (2008). Bitcoin: A Peer-to-Peer Electronic Cash System. Retrieved from https://bitcoin.org/bitcoin.pdf
-(The original Bitcoin white paper introducing the P2P transaction framework and blockchain, which QMoney adapts for its decentralized verification.)
-- Wiesner, S. (1983). Conjugate coding. SIGACT News, 15(1), 78–88.
-(Originally written in 1969, published later; introduces quantum money using quantum states, foundational to QMoney’s unforgeability.)
-- Wootters, W. K., & Zurek, W. H. (1982). A single quantum cannot be cloned. Nature, 299(5886), 802–803.
-(Establishes the no-cloning theorem, the core security principle preventing counterfeiting in QMoney.)
-- Nielsen, M. A., & Chuang, I. L. (2010). Quantum Computation and Quantum Information. Cambridge University Press.
-(A standard reference for quantum mechanics concepts like qubits, superposition, and the Hadamard gate, used in QMoney’s 2-qubit scheme.)
-- Shor, P. W. (1997). Polynomial-time algorithms for prime factorization and discrete logarithms on a quantum computer. SIAM Journal on Computing, 26(5), 1484–1509.
-(Describes Shor’s algorithm, highlighting Bitcoin’s vulnerability to quantum attacks, motivating QMoney’s quantum-resistant design.)
-- Grover, L. K. (1996). A fast quantum mechanical algorithm for database search. Proceedings of the 28th Annual ACM Symposium on Theory of Computing (STOC '96), 212–219.
-(Introduces Grover’s algorithm, relevant to QMoney’s scalability challenges with larger qubit counts.)
-
-## Demo (Software MPS Quorum)
 Run the pure software simulator demo:
+
 - `python qmoney_mps_quorum_demo.py --n 512`
 - `python qmoney_mps_quorum_demo.py --n 1024`
+
+The current simulator keeps the note family intentionally simple:
+- BB84 product states
+- quorum-held verification secrets
+- very low entanglement
+- MPS-friendly scaling for larger software-only experiments
+
+This is a useful private-key baseline, not a claim of true public-key quantum money.
+
+---
+
+## Research direction
+
+The repo should be read as having two tracks:
+
+### Track A — current baseline
+- distributed private-key quantum cash
+- secret-holding verifier quorum
+- verify-and-remint
+- classical settlement layer
+
+### Track B — future research
+- true public-key note families
+- hidden-subspace/oracle-backed prototypes
+- stronger coherence-sensitive verification
+- public-key constructions clearly separated from the current baseline
+
+---
+
+## Citations
+
+- Nakamoto, S. (2008). *Bitcoin: A Peer-to-Peer Electronic Cash System*. https://bitcoin.org/bitcoin.pdf
+- Wiesner, S. (1983). *Conjugate coding*. SIGACT News, 15(1), 78–88. (Written in the late 1960s; foundational private-key quantum money idea.)
+- Wootters, W. K., & Zurek, W. H. (1982). *A single quantum cannot be cloned*. Nature, 299(5886), 802–803.
+- Aaronson, S., & Christiano, P. (2012). *Quantum Money from Hidden Subspaces*. https://www.scottaaronson.com/papers/moneyfull.pdf
+- Shor seminar note in this repo: [`docs/research/shor-arguments-and-qmoney-integration.md`](docs/research/shor-arguments-and-qmoney-integration.md)
+- Aaronson transcript-backed note in this repo: [`docs/research/aaronson-private-key-quantum-money-and-qmoney.md`](docs/research/aaronson-private-key-quantum-money-and-qmoney.md)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,62 @@ The current simulator keeps the note family intentionally simple:
 
 This is a useful private-key baseline, not a claim of true public-key quantum money.
 
+### Actual implementation sample
+
+The implementation lives in [`qmoney_mps_quorum_demo.py`](qmoney_mps_quorum_demo.py). At a high level it exposes:
+- `Ledger` for spent-state and owner tracking
+- `QuorumNode` for secret-holding verifiers
+- `QuorumService` for minting plus `verify_and_remint`
+- `Bill` / `BillSecret` for the note and its hidden verification data
+
+A minimal end-to-end example from the current implementation looks like this:
+
+```python
+from qmoney_mps_quorum_demo import Ledger, QuorumNode, QuorumService
+
+nodes = [QuorumNode(i) for i in range(4)]
+quorum = QuorumService(nodes, threshold=3)
+ledger = Ledger()
+
+bill = quorum.mint_bill(32, owner="alice", ledger=ledger)
+
+accepted, new_bill = quorum.verify_and_remint(
+    bill,
+    claimant="alice",
+    receiver="bob",
+    ledger=ledger,
+    tolerance=0,
+    noise_bitflip_p=0.0,
+    seed=123,
+)
+
+print("accepted", accepted)
+print("old spent", ledger.is_spent(bill.serial))
+print("new owner", ledger.owner_of(new_bill.serial) if new_bill else None)
+```
+
+The built-in CLI demo then shows the intended system behavior:
+
+```bash
+python qmoney_mps_quorum_demo.py --n 32 --nodes 4 --threshold 3 --forge-trials 10000
+```
+
+Expected shape of output:
+
+```text
+transfer alice->bob accepted=True
+double-spend accepted=False
+new serial minted to bob: <hex-serial>
+forge success rate: <x>/10000
+```
+
+That sample captures the current implementation thesis of the repo:
+- mint a private-key BB84-style note
+- let a quorum verify it using hidden basis/bit data
+- consume the original note on verification
+- re-mint a fresh note for the receiver
+- reject double-spend attempts at the ledger layer
+
 ---
 
 ## Research direction

--- a/docs/architecture/software-mps-quorum-design.md
+++ b/docs/architecture/software-mps-quorum-design.md
@@ -1,0 +1,252 @@
+# Software MPS Quorum Design for QMoney
+
+This document preserves the original technical appendix-style design for the current QMoney simulator track.
+
+It describes the simplest software-only path to a larger-qubit **quorum-verified private-key quantum cash** system using:
+- BB84 product states
+- verifier-held secret basis/bit data
+- verify-and-remint semantics
+- very low entanglement, so the bill remains MPS-friendly
+
+This is a **private-key** design note for the current baseline, not a public-key quantum money construction.
+
+---
+
+## 1. Design goal
+
+The baseline simulator targets a path to **512 or 1024 qubits** that:
+- keeps the quantum note easy to simulate in software
+- supports **public access to verification requests** via a verifier quorum
+- avoids exotic public-key quantum money constructions
+- uses a BB84 product-state note family with MPS bond dimension `D=1`
+
+The key architectural move is:
+- keep the quantum note family simple and private-key
+- put distributed coordination in the classical settlement/quorum layer
+
+---
+
+## 2. Verification by a quorum, not by the bill holder
+
+The simplest scalable design for the current repo is to make verification an **online quorum service**.
+
+### Core model
+- A verifier quorum collectively holds the bill’s hidden verification data.
+- The bill holder does **not** learn the full verification secret.
+- Verification consumes the presented note by measurement.
+- If valid, the quorum re-mints a fresh note for the receiver.
+
+This preserves the core anti-counterfeiting story:
+- the note is hard to clone because the secret measurement rule remains hidden
+- the system can still circulate value through verify-and-remint
+
+This is “public” only in the limited sense that **anyone can request verification from the network**. It is **not** non-interactive public-key quantum money.
+
+---
+
+## 3. Data model
+
+For a bill with `n ∈ {512, 1024}` qubits:
+
+- `serial`: unique identifier, e.g. 128-bit random
+- `owner_pk`: current owner public key in the classical ledger
+- `C`: optional public commitment to hidden verification data, e.g. `C = H(serial || B || V || nonce)`
+
+Hidden verifier-held data:
+- `B ∈ {0,1}^n`
+  - `B[i]=0` means measure qubit `i` in the Z basis
+  - `B[i]=1` means measure qubit `i` in the X basis
+- `V ∈ {0,1}^n`
+  - expected outcome in that basis
+
+In the current simulator, these are represented concretely by `BillSecret.basis` and `BillSecret.bits`.
+
+---
+
+## 4. Quantum state preparation
+
+Each qubit `i` is prepared as a BB84 state:
+
+- if `B[i]=0` and `V[i]=0`: `|0⟩`
+- if `B[i]=0` and `V[i]=1`: `|1⟩`
+- if `B[i]=1` and `V[i]=0`: `|+⟩`
+- if `B[i]=1` and `V[i]=1`: `|−⟩`
+
+The full bill is a tensor product of these single-qubit states.
+
+### Why this matters
+Because the bill is a product state:
+- it has **very low entanglement**
+- it is naturally representable as an MPS with bond dimension `D=1`
+- software simulation scales linearly in `n` as long as no entangling gates are introduced
+
+That is why this note family is a good software baseline.
+
+---
+
+## 5. Verify-and-remint protocol
+
+A system-level transfer looks like this:
+
+1. **Transfer intent**
+   - sender creates a classical transfer intent naming `(old_serial, receiver_pk, ...)`
+   - sender signs it with the classical ownership key
+
+2. **Present bill**
+   - sender submits the quantum note plus transfer intent to the verifier quorum
+
+3. **Quorum verification**
+   - the quorum measures the note in the secret bases `B`
+   - it checks the resulting outcomes against `V`
+   - all qubits are checked across the participating quorum members
+
+4. **Ledger update**
+   - if accepted: mark `old_serial` spent and attach the new note to `receiver_pk`
+   - if rejected after measurement: mark `old_serial` spent/invalid, since the state was consumed
+   - if a quorum cannot be assembled **before verification starts**: abort and leave the original note live
+
+5. **Re-mint**
+   - the quorum generates a fresh `(new_serial, B', V')`
+   - the quorum prepares a fresh `n`-qubit note for the recipient
+
+This gives one-time quantum spend semantics with repeated circulation achieved by re-minting.
+
+---
+
+## 6. Mapping to the current implementation
+
+The current code implementing this baseline is in [`qmoney_mps_quorum_demo.py`](../../qmoney_mps_quorum_demo.py).
+
+### Main objects
+- `Bill`
+  - current note: serial + qubit list
+- `BillSecret`
+  - hidden basis/bit verification rule
+- `Ledger`
+  - spent-state and owner tracking
+- `QuorumNode`
+  - secret-holding verifier node
+- `QuorumService`
+  - minting and `verify_and_remint`
+
+### Current implementation behavior
+The implementation currently guarantees:
+- a bill is only verified if quorum participation is available
+- if quorum is unavailable before verification starts, the bill remains live
+- if verification starts, the bill is consumed by measurement
+- all qubits are measured across the quorum, not just a threshold prefix
+- accepted bills are re-minted with a fresh serial for the receiver
+- double-spend attempts fail at the ledger layer
+
+The test coverage in `tests/test_qmoney.py` currently checks:
+- all qubits are measured even when threshold is less than node count
+- a bill is not spent when quorum cannot be assembled before verification begins
+
+---
+
+## 7. MPS / simulation requirements
+
+For this baseline note family, the simulator only needs:
+- single-qubit state preparation
+- Hadamard transforms for X-basis measurement
+- projective measurement with collapse
+- optional simple noise channels like per-qubit bit-flip
+
+### Practical rule of thumb
+- ordinary state-vector simulation is comfortable up to roughly `30–32` logical qubits
+- beyond that, low-entanglement tensor-network / MPS methods become the natural route
+- for this specific product-state note family, bond dimension stays `D=1` unless the design is changed to introduce entanglement
+
+That is why the repo can legitimately target larger software-only qubit counts while keeping the current note family simple.
+
+---
+
+## 8. Acceptance rule and noise tolerance
+
+A baseline acceptance rule is:
+- measure all `n` qubits
+- accept if `matches ≥ n - t`
+
+Where:
+- `matches` = number of outcomes matching the hidden secret bits
+- `t` = allowed mismatch budget from noise or implementation tolerance
+
+### Current implementation parameters
+The demo exposes:
+- `--tolerance`
+- `--noise-bitflip`
+- `--seed`
+
+This allows the simulator to explore:
+- exact-match acceptance (`t=0`)
+- simple noisy channels
+- forged-note failure under imperfect measurement conditions
+
+---
+
+## 9. Security intuition for the baseline
+
+In the simplest intercept/resend model, a counterfeiter without `B` must guess a basis for each qubit.
+
+Per qubit, success is:
+- correct basis: success probability `1`
+- wrong basis: success probability `1/2`
+
+Averaging over hidden bases gives:
+- per-qubit success probability `3/4`
+
+So for exact matching on all qubits:
+- `P_forge = (3/4)^n`
+
+Security bits are approximately:
+- `s = -log2(P_forge) = n * log2(4/3) ≈ 0.415 * n`
+
+Examples:
+- `n=512` → about `212.5` bits
+- `n=1024` → about `425` bits
+
+This is only the simple product-state intercept/resend threat model, but it is the right baseline story for the current simulator track.
+
+---
+
+## 10. Suggested software-only parameters
+
+Good starting points for the baseline simulator:
+
+- qubits per bill: `n=512` or `n=1024`
+- threshold: `2f+1` approvals out of `3f+1` nodes
+- tolerance: start with `0`, then introduce small mismatch budgets under noise
+- secret storage:
+  - start with full replication across quorum nodes in software
+  - later explore threshold sharing or partial secret distribution
+
+The current demo is intentionally conservative and simple. Its job is to make the architecture clear and executable, not to claim a production-ready quantum money system.
+
+---
+
+## 11. Why keep this design note separate from the README
+
+The README should stay short and repo-facing.
+
+This document exists to preserve the more technical appendix-style material:
+- larger-qubit simulator target
+- concrete note data model
+- exact protocol flow
+- acceptance/tolerance mechanics
+- forge-rate intuition
+- implementation mapping
+
+That makes this the right place for the original appendix content to live going forward.
+
+---
+
+## 12. Status
+
+This document matches the **current private-key baseline**.
+
+It should evolve only when the implementation meaningfully changes, for example if QMoney adds:
+- entangled note families
+- more realistic noise models
+- threshold-shared secrets in code
+- richer quorum fault handling
+- a separate public-key note-family namespace


### PR DESCRIPTION
## Summary
- rewrite the README to be shorter and more repo-facing
- center the project framing on Wiesner/Shor no-cloning ideas, Aaronson private-key quantum money ideas, and Bitcoin-inspired distributed settlement
- clarify that current QMoney is a distributed private-key quantum cash system with verify-and-remint semantics, not public-key quantum money
- keep citations and repo reference links aligned with the current research notes

## Notes
- keeps roadmap, video-memo, and Whisper transcript artifacts local and out of the PR

## Test Plan
- docs-only change