### PR TITLE
[verified] docs: add latest quantum money literature survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ not near-term deployment of production quantum money.
 - [`docs/research/shor-arguments-and-qmoney-integration.md`](docs/research/shor-arguments-and-qmoney-integration.md) — how Peter Shor’s arguments should shape QMoney’s architecture split, terminology, and public-key research boundaries.
 - [`docs/research/aaronson-private-key-quantum-money-and-qmoney.md`](docs/research/aaronson-private-key-quantum-money-and-qmoney.md) — transcript-backed note on Aaronson’s private-key quantum money ideas, adaptive-query security, compact-secret tradeoffs, and why QMoney fits the distributed private-key lineage.
 - [`docs/research/wiesner-counterfeiting-attacks-and-qmoney.md`](docs/research/wiesner-counterfeiting-attacks-and-qmoney.md) — evaluation of Molina–Vidick–Watrous (2012) for QMoney, including why the paper's one-note-to-two-notes counterfeiting model is a strong fit for the current private-key baseline.
+- [`docs/research/latest-quantum-money-literature-and-qmoney.md`](docs/research/latest-quantum-money-literature-and-qmoney.md) — survey of the latest quantum money literature most relevant to QMoney, prioritizing Wiesner, Shor, Aaronson/Christiano, Zhandry, and recent oracle/noise-tolerant directions.
+- [`docs/research/quantum-money-literature-roadmap.md`](docs/research/quantum-money-literature-roadmap.md) — ranked reading and prototyping roadmap for QMoney: what to read next, prototype next, monitor, and avoid.
 
 ---
 
@@ -238,6 +240,24 @@ The repo should be read as having two tracks:
 - hidden-subspace/oracle-backed prototypes
 - stronger coherence-sensitive verification
 - public-key constructions clearly separated from the current baseline
+- group-action, oracle/noise-tolerant, and anonymity-aware literature tracked as separate design directions
+
+---
+
+## Latest research directions
+
+Recent literature reinforces that QMoney's public-key future should be treated as a separate research program rather than as a small extension of the current BB84/quorum baseline.
+
+The most important newer directions to watch are:
+- **noise-tolerant public-key money from classical oracles** — especially promising for QMoney's formal/oracle workflow
+- **public-key money from abelian group actions** — one of the strongest modern public-key directions
+- **cryptanalysis of public-key money schemes** — essential to keep prototype claims honest
+- **anonymous public-key money** — relevant if QMoney ever combines public verification with privacy-sensitive circulation
+- **copy-complexity / unclonable-cryptography frameworks** — useful for broadening QMoney's attack models beyond a single counterfeit story
+
+See:
+- [`docs/research/latest-quantum-money-literature-and-qmoney.md`](docs/research/latest-quantum-money-literature-and-qmoney.md)
+- [`docs/research/quantum-money-literature-roadmap.md`](docs/research/quantum-money-literature-roadmap.md)
 
 ---
 
@@ -248,6 +268,8 @@ The repo should be read as having two tracks:
 - Wootters, W. K., & Zurek, W. H. (1982). *A single quantum cannot be cloned*. Nature, 299(5886), 802–803.
 - Aaronson, S., & Christiano, P. (2012). *Quantum Money from Hidden Subspaces*. https://www.scottaaronson.com/papers/moneyfull.pdf
 - Molina, A., Vidick, T., & Watrous, J. (2012). *Optimal counterfeiting attacks and generalizations for Wiesner's quantum money*. https://arxiv.org/abs/1202.4010
+- Zhandry, M. (2023). *Quantum Money from Abelian Group Actions*. https://arxiv.org/abs/2307.12120
+- Yuen, P. (2024). *Noise-tolerant public-key quantum money from a classical oracle*. https://arxiv.org/abs/2407.06463
 
 ## Additional references
 - Scott Aaronson, *Stephen Wiesner (1942-2021)*: https://scottaaronson.blog/?p=5730

--- a/docs/research/latest-quantum-money-literature-and-qmoney.md
+++ b/docs/research/latest-quantum-money-literature-and-qmoney.md
@@ -1,0 +1,236 @@
+# Latest Quantum Money Literature and QMoney
+
+This note surveys the most relevant **recent quantum money research** for QMoney, prioritizing the authors and research lines already referenced in the repo:
+
+- Stephen Wiesner
+- Peter Shor
+- Scott Aaronson / Paul Christiano
+- and the nearest modern continuations of those lines, especially Mark Zhandry and newer public-key / oracle / unclonable-cryptography work
+
+The goal is not to list every paper with the words *quantum money*, but to identify which recent directions actually matter for QMoney's architecture and research roadmap.
+
+## Executive summary
+
+The latest serious momentum in the field is **not** a direct continuation of the BB84/Wiesner-style private-key line. Instead, current activity is concentrated in:
+
+1. **new public-key constructions** based on richer algebraic structure,
+2. **noise-tolerant verification models** that move closer to realistic hardware,
+3. **cryptanalysis** of candidate public-key schemes,
+4. and a broader **unclonable-cryptography framework** where quantum money is only one primitive among many.
+
+For QMoney, the core conclusion is:
+
+> The current private-key / quorum / verify-and-remint baseline still looks like the right honest present-day position, while the public-key frontier remains active but fragile, cryptanalysis-heavy, and structurally quite different from the repo's BB84-style baseline.
+
+---
+
+## 1. Wiesner: still the conceptual anchor
+
+The field still treats Wiesner as the origin of the discipline:
+- private-key verification,
+- hidden note information,
+- no-cloning as the anti-counterfeiting primitive,
+- banknote-style quantum states that are physically hard to copy.
+
+A recent practical-facing signal is:
+- **Kukharchyk et al. (2026), _Practical quantum tokens: challenges and perspectives_**, `arXiv:2602.10621`
+
+This is not a new public-key breakthrough. It is more of a systems-and-engineering reality check: the community is increasingly asking what token-like quantum cryptography would look like under actual hardware constraints.
+
+### QMoney relevance
+- reinforces keeping Wiesner as the historical baseline,
+- supports the repo's continued emphasis on honest private-key framing,
+- and suggests that practical token engineering is still far behind elegant theory.
+
+---
+
+## 2. Peter Shor: important historically, cautionary in recent public-key directions
+
+Peter Shor remains central to QMoney's framing because his perspective helps motivate why quantum-era money and settlement systems matter at all.
+
+The most relevant recent Shor-linked public-key item found here is:
+- **Khesin, Lu, Shor (2022), _Publicly verifiable quantum money from random lattices_**, `arXiv:2207.13135`
+
+However, this paper is now explicitly marked on arXiv as **withdrawn** because a central calculation was incorrect, with an accompanying warning that schemes of similar form may fail more generally.
+
+Older Shor-linked work remains historically important:
+- _Breaking and making quantum money_ (2009)
+- _Quantum money from knots_ (2010)
+
+### QMoney relevance
+The main lesson is not “Shor gives QMoney a clean public-key route.” The lesson is almost the opposite:
+
+- candidate public-key constructions can look promising and still break,
+- elegant public-verification ideas are brittle,
+- and QMoney should remain conservative about public-key claims.
+
+---
+
+## 3. Aaronson / Christiano: still the canonical conceptual dividing line
+
+The foundational public-key reference remains:
+- **Aaronson, Christiano (2012), _Quantum Money from Hidden Subspaces_**, `arXiv:1203.4740`
+
+This remains the canonical paper for explaining why public-key quantum money is a fundamentally different note-family/verifier problem from Wiesner-style private-key money.
+
+But the recent literature also shows that hidden-subspace-style thinking should be treated as:
+- conceptually decisive,
+- historically foundational,
+- and still useful as a prototype template,
+- but **not automatically secure merely because it is elegant**.
+
+A major follow-up here is:
+- **Bilyk, Doliskani, Gong (2022), _Cryptanalysis of Three Quantum Money Schemes_**, `arXiv:2205.10488`
+
+That cryptanalysis specifically reinforces the broader lesson that older public-key candidates need to be treated as attack surfaces, not finished blueprints.
+
+### QMoney relevance
+For QMoney, Aaronson/Christiano still matters in three ways:
+
+1. it justifies keeping the public-key track **separate** from the private-key baseline,
+2. it motivates the repo's `pubkey_hidden_subspace/` namespace as a research area rather than a production claim,
+3. and it warns against confusing conceptual prototype progress with cryptographic closure.
+
+---
+
+## 4. Zhandry and the group-action line: one of the strongest modern public-key directions
+
+The most important modern continuation I found is:
+- **Mark Zhandry (2023 / journal 2025), _Quantum Money from Abelian Group Actions_**, `arXiv:2307.12120`
+
+This is a major shift away from BB84-style product states and toward algebraic public-key structure. It is one of the clearest modern candidates for a real public-key quantum money / quantum lightning direction.
+
+Related follow-on work includes:
+- **Mutreja, Zhandry (2024), _Quantum State Group Actions_**, `arXiv:2410.08547`
+- **Bostanci, Nehoran, Zhandry (2024), _A General Quantum Duality for Representations of Groups with Applications to Quantum Money, Lightning, and Fire_**, `arXiv:2411.00529`
+
+### QMoney relevance
+If QMoney wants a serious public-key research track, this group-action family is more promising than trying to stretch the current BB84/quorum baseline into something it is not.
+
+This does **not** mean QMoney should pivot immediately into implementation. It means that the repo's future note-family comparison work should treat group-action constructions as first-class reference points.
+
+---
+
+## 5. Noise-tolerant public-key money: especially relevant to QMoney's oracle/formal workflow
+
+A particularly relevant recent paper is:
+- **Peter Yuen (2024 / Quantum 2025), _Noise-tolerant public-key quantum money from a classical oracle_**, `arXiv:2407.06463`
+
+This matters because it addresses something older public-key literature often idealized away:
+- **noise tolerance**
+- and explicitly **classical-oracle-mediated** public verification structure.
+
+### QMoney relevance
+This paper is unusually relevant to QMoney's current formal-research direction because:
+- the repo already has a public-key/oracle workflow,
+- the repo already distinguishes runtime math from oracle/lifecycle/formal layers,
+- and any realistic public-key future for QMoney will eventually need noise tolerance.
+
+If the public-key track keeps evolving, this is one of the best papers to prioritize after the classical Aaronson-Christiano background.
+
+---
+
+## 6. Anonymous public-key money: beyond bare counterfeiting
+
+Another major newer direction is:
+- **Çakan, Goyal, Yamakawa (2024), _Anonymous Public-Key Quantum Money and Quantum Voting_**, `arXiv:2411.04482`
+
+This expands the design question from simple public verification toward:
+- holder privacy,
+- anonymity,
+- and composability with higher-level systems such as voting.
+
+### QMoney relevance
+For QMoney this matters mostly at the systems layer:
+- if the project ever wants to connect quantum notes with Bitcoin-like circulation and ownership semantics,
+- then public verifiability alone is not enough,
+- and anonymity/privacy properties may become first-class design criteria.
+
+---
+
+## 7. New construction variants and transform choices
+
+A recent example here is:
+- **Doliskani, Mirzaei, Mousavi (2025), _Public-Key Quantum Money and Fast Real Transforms_**, `arXiv:2503.18890`
+
+The key idea is that the field is still actively experimenting with **which transform family** should underwrite public verification, including choices that keep amplitudes real rather than complex.
+
+### QMoney relevance
+This is less immediately actionable than the group-action or noise-tolerant oracle lines, but it is strong evidence that the public-key frontier remains highly exploratory. QMoney should track this as part of a note-family comparison discipline rather than prematurely settling on one public-key template.
+
+---
+
+## 8. The field is broadening into unclonable cryptography
+
+Several recent papers are not just “quantum money papers,” but they matter because they generalize the entire area:
+
+- **Ananth, Behera (2023), _A Modular Approach to Unclonable Cryptography_**, `arXiv:2311.11890`
+- **Ananth, Kaleoglu, Liu (2023), _Cloning Games: A General Framework for Unclonable Primitives_**, `arXiv:2302.01874`
+- **Çakan, Goyal, Kitagawa, Nishimaki, Yamakawa (2025), _Multi-Copy Security in Unclonable Cryptography_**, `arXiv:2510.12626`
+- **Ananth, Goldin (2025), _Less is More: On Copy Complexity in Quantum Cryptography_**, `arXiv:2510.04992`
+
+### QMoney relevance
+This meta-cryptographic shift matters because it says the next generation of questions is not just:
+- “can notes be cloned?”
+
+but also:
+- how many copies matter,
+- what adversarial copy access is allowed,
+- how to modularize unclonable primitives,
+- which assumptions are actually minimal.
+
+This strongly supports QMoney evolving from a single counterfeit narrative into a **family of attack models** and **copy-complexity-sensitive security questions**.
+
+---
+
+## 9. Recommended prioritization for QMoney
+
+## Read next
+These are the most useful next reading targets for the repo:
+
+1. **Yuen (2024/2025)** — _Noise-tolerant public-key quantum money from a classical oracle_ (`2407.06463`)
+2. **Zhandry (2023/2025)** — _Quantum Money from Abelian Group Actions_ (`2307.12120`)
+3. **Bilyk, Doliskani, Gong (2022)** — _Cryptanalysis of Three Quantum Money Schemes_ (`2205.10488`)
+4. **Çakan, Goyal, Yamakawa (2024)** — _Anonymous Public-Key Quantum Money and Quantum Voting_ (`2411.04482`)
+5. **Doliskani, Mirzaei, Mousavi (2025)** — _Public-Key Quantum Money and Fast Real Transforms_ (`2503.18890`)
+
+## Prototype next
+If QMoney wants to deepen Track B, the most promising prototype inspirations are:
+
+1. **noise-tolerant oracle models**
+2. **group-action / representation-based constructions**
+3. **explicit copy-complexity / multi-copy threat modeling**
+
+## Monitor only
+Worth tracking, but not immediate implementation targets:
+
+- practical quantum token engineering papers
+- anonymity/voting extensions until the base note family is stronger
+- transform-family variants unless QMoney adopts a stronger public-key backbone first
+
+## Avoid / treat skeptically
+- withdrawn or already-broken public-key candidates
+- any attempt to relabel the BB84/quorum baseline as “basically public-key”
+- any construction that ignores noise, leakage, or cryptanalysis pressure
+
+---
+
+## Bottom line for QMoney
+
+The modern literature supports a very specific position:
+
+> QMoney's current private-key / quorum / verify-and-remint baseline remains the right honest architecture for the repo today. The public-key frontier is active and exciting, but it has moved into group actions, oracle/noise-tolerant verification, anonymity extensions, and unclonable-cryptography frameworks that are structurally different from the current BB84-style baseline.
+
+That means QMoney should keep doing two things at once:
+- continue strengthening the current private-key baseline and its attack models,
+- while treating public-key quantum money as a genuinely separate note-family research program.
+
+## Selected references
+
+- Peter Yuen, *Noise-tolerant public-key quantum money from a classical oracle*, `arXiv:2407.06463`
+- Mark Zhandry, *Quantum Money from Abelian Group Actions*, `arXiv:2307.12120`
+- Alper Çakan, Vipul Goyal, Takashi Yamakawa, *Anonymous Public-Key Quantum Money and Quantum Voting*, `arXiv:2411.04482`
+- Jake Doliskani, Morteza Mirzaei, Ali Mousavi, *Public-Key Quantum Money and Fast Real Transforms*, `arXiv:2503.18890`
+- Andriyan Bilyk, Javad Doliskani, Zhiyong Gong, *Cryptanalysis of Three Quantum Money Schemes*, `arXiv:2205.10488`
+- Scott Aaronson, Paul Christiano, *Quantum Money from Hidden Subspaces*, `arXiv:1203.4740`
+- Peter W. Shor et al., *Publicly verifiable quantum money from random lattices*, `arXiv:2207.13135` (withdrawn)

--- a/docs/research/quantum-money-literature-roadmap.md
+++ b/docs/research/quantum-money-literature-roadmap.md
@@ -1,0 +1,140 @@
+# QMoney Quantum Money Literature Roadmap
+
+This roadmap ranks current literature directions by how useful they are for QMoney **right now**.
+
+## Read next
+
+### 1. Noise-tolerant public-key money from a classical oracle
+- **Peter Yuen (2024 / Quantum 2025)**
+- `arXiv:2407.06463`
+
+Why:
+- unusually close to QMoney's public-key/oracle workflow,
+- explicitly addresses noise tolerance,
+- bridges abstract public-key theory with more realistic verifier conditions.
+
+### 2. Quantum Money from Abelian Group Actions
+- **Mark Zhandry (2023 / journal 2025)**
+- `arXiv:2307.12120`
+
+Why:
+- one of the strongest modern public-key directions,
+- structurally different from BB84/Wiesner notes,
+- important for any serious Track B roadmap.
+
+### 3. Cryptanalysis of Three Quantum Money Schemes
+- **Bilyk, Doliskani, Gong (2022)**
+- `arXiv:2205.10488`
+
+Why:
+- reminds QMoney that public-key elegance is not enough,
+- directly relevant to how prototype claims should be bounded,
+- useful as an honesty check for hidden-subspace-style work.
+
+### 4. Anonymous Public-Key Quantum Money and Quantum Voting
+- **Çakan, Goyal, Yamakawa (2024)**
+- `arXiv:2411.04482`
+
+Why:
+- extends the conversation from counterfeit-resistance to privacy and holder anonymity,
+- relevant if QMoney ever tries to combine quantum notes with Bitcoin-like public circulation.
+
+### 5. Public-Key Quantum Money and Fast Real Transforms
+- **Doliskani, Mirzaei, Mousavi (2025)**
+- `arXiv:2503.18890`
+
+Why:
+- evidence that the public-key frontier is still experimenting with transform choices,
+- useful for note-family comparison, even if not the first prototype target.
+
+---
+
+## Prototype next
+
+These are not immediate production candidates, but they are the best directions for deeper QMoney experimentation.
+
+### A. Noise-tolerant oracle models
+Best near-term fit for QMoney's existing formal/oracle workflow.
+
+### B. Group-action / representation-based note families
+Best candidate family for a truly separate public-key note track.
+
+### C. Copy-complexity and multi-copy attack modeling
+Important for strengthening the current private-key baseline and for preventing overly narrow counterfeit models.
+
+---
+
+## Monitor only
+
+These are worth watching, but should not outrank the items above.
+
+### Practical quantum token engineering
+- e.g. `arXiv:2602.10621`
+
+Why monitor:
+- valuable for eventual implementation realism,
+- but too early to drive core cryptographic architecture.
+
+### Anonymity / voting extensions
+Why monitor:
+- important for future systems design,
+- but secondary until the base note-family direction is stronger.
+
+### Transform-family variants
+Why monitor:
+- useful comparison points,
+- but not a reason to reorient QMoney by themselves.
+
+---
+
+## Avoid / treat skeptically
+
+### Withdrawn or broken public-key schemes
+Example:
+- **Khesin, Lu, Shor (2022)**, `arXiv:2207.13135` — withdrawn
+
+Lesson:
+- public-key quantum money proposals can fail in subtle ways,
+- so QMoney should treat cryptanalysis as part of the mainline literature, not an afterthought.
+
+### Rebranding the private-key baseline as public-key
+Avoid:
+- suggesting the current BB84/quorum model is “close enough” to public-key money,
+- collapsing the difference between public ownership tracking and public quantum verification.
+
+### Ignoring noise or leakage
+Avoid:
+- public-key prototypes that rely on unrealistically clean verification,
+- security narratives that omit repeated-query leakage or verifier-side attack surfaces.
+
+---
+
+## What to do in the repo
+
+## For Track A — private-key baseline
+Prioritize:
+- adaptive verification attacks,
+- verifier leakage,
+- one-note-to-two-notes counterfeit modeling,
+- remint-side-channel analysis,
+- multi-copy / copy-complexity framing.
+
+## For Track B — public-key research
+Prioritize:
+- oracle/noise-tolerant note-family comparisons,
+- group-action references and conceptual mapping,
+- explicit “prototype only” documentation for any hidden-subspace or public-key experiments,
+- cryptanalysis notes alongside constructions.
+
+---
+
+## Short version
+
+If time is limited, QMoney should do this in order:
+
+1. read **Yuen 2024/2025**
+2. read **Zhandry 2023/2025**
+3. read **cryptanalysis of public-key schemes**
+4. only then deepen implementation experiments
+
+That ordering keeps the project anchored in realistic public-key research rather than in optimism alone.


### PR DESCRIPTION
## Summary
- add a new research note surveying the latest quantum money literature most relevant to QMoney
- prioritize the repo’s existing reference lineages: Wiesner, Shor, Aaronson/Christiano
- connect those references to newer directions including group actions, oracle/noise-tolerant public-key money, anonymity, and unclonable-cryptography frameworks
- patch the README with a latest-research section and links
- add a ranked literature roadmap for what QMoney should read next, prototype next, monitor, and avoid

## Why
This makes the repo’s research direction more current and better organized. It also helps keep the private-key baseline honest while clarifying which modern public-key directions are actually worth tracking.

## Test Plan
- docs-only change
- static scan: no findings
- independent docs review: passed