### PR TITLE
docs: clarify simulator vs quantum hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,22 @@ The current simulator keeps the note family intentionally simple:
 - very low entanglement
 - MPS-friendly scaling for larger software-only experiments
 
-This is a useful private-key baseline, not a claim of true public-key quantum money.
+### BB84 abstraction: simulator vs quantum hardware
+
+For the current baseline, BB84 only requires:
+- preparation in the `Z` or `X` basis
+- basis-dependent measurement
+- classical reconciliation about which basis was used
+
+The important distinction is:
+- **classical simulator** = models those qubits and measurements as software objects and computed probabilities
+- **quantum hardware** = prepares and measures real physical qubits, so disturbance, noise, and loss happen in the physical system
+
+In other words:
+- a **classical simulator models BB84**
+- **quantum hardware performs BB84**
+
+This repo's current baseline is a **classical simulator** for a BB84-style private-key note family. It is a useful research and engineering environment, not a claim that the current implementation already runs on production quantum hardware.
 
 A useful baseline attack model for this simulator family is the **simple one-note-to-two-notes counterfeiting attack** analyzed by Molina, Vidick, and Watrous (2012): given one valid note, what is the best probability of producing two notes that both pass verification? See [`docs/research/wiesner-counterfeiting-attacks-and-qmoney.md`](docs/research/wiesner-counterfeiting-attacks-and-qmoney.md).
 

--- a/docs/architecture/public-vs-private-key-qmoney.md
+++ b/docs/architecture/public-vs-private-key-qmoney.md
@@ -31,6 +31,16 @@ The bill is secure against simple counterfeiting because an adversary does **not
 
 This is the core reason the current system is **private-key** at the quantum layer.
 
+#### Classical simulator vs quantum hardware
+For this BB84-style abstraction, the current repo should distinguish two very different execution modes:
+
+- **Classical simulator:** qubits are represented as software state, measurement outcomes are computed, and eavesdropping/noise are modeled by the program.
+- **Quantum hardware:** qubits are real physical states, measurements are physically performed, and disturbance/noise/loss arise in the hardware and channel itself.
+
+So the honest statement is:
+- the current repo **simulates** BB84-style quantum money behavior
+- it does **not** yet implement the note family on real quantum hardware
+
 ### 1.2 Classical ledger / ownership layer
 Separately, QMoney uses ordinary classical cryptographic ideas for:
 - ownership identity

--- a/docs/architecture/software-mps-quorum-design.md
+++ b/docs/architecture/software-mps-quorum-design.md
@@ -239,7 +239,11 @@ For this baseline note family, the simulator only needs:
 - beyond that, low-entanglement tensor-network / MPS methods become the natural route
 - for this specific product-state note family, bond dimension stays `D=1` unless the design is changed to introduce entanglement
 
-That is why the repo can legitimately target larger software-only qubit counts while keeping the current note family simple.
+### Classical simulator requirement vs quantum hardware requirement
+- **Classical requirement:** enough conventional compute and memory to simulate the logical qubit count of interest; dense state-vector methods top out around `30–32` logical qubits before MPS/tensor-network methods become preferable.
+- **Quantum hardware requirement:** enough real, controllable logical qubits to prepare, preserve, and measure the target note family with acceptable noise and loss.
+
+That is why the repo can legitimately target larger software-only qubit counts while keeping the current note family simple, while still being honest that real hardware deployment is a different requirement boundary.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify the BB84 abstraction in the README
- make the distinction between classical simulators and quantum hardware explicit
- document the requirement split between classical dense simulation limits and real logical-qubit hardware requirements

## What changed

### README
- added a new **“BB84 abstraction: simulator vs quantum hardware”** section
- states clearly that:
  - **classical simulators model BB84**
  - **quantum hardware performs BB84**
- clarifies that the current repo baseline is a **classical simulator** for a BB84-style private-key note family, not a production quantum-hardware implementation

### docs/architecture/public-vs-private-key-qmoney.md
- added a **“Classical simulator vs quantum hardware”** subsection under the quantum note layer
- clarifies that the repo currently simulates BB84-style quantum money behavior rather than implementing it on real hardware

### docs/architecture/software-mps-quorum-design.md
- added a **“Classical simulator requirement vs quantum hardware requirement”** subsection
- distinguishes:
  - **classical requirement**: enough conventional compute/memory for logical-qubit simulation
  - **quantum hardware requirement**: enough real controllable logical qubits with acceptable noise/loss
- preserves the rule of thumb that dense state-vector simulation is comfortable up to roughly **30–32 logical qubits**

## Why
Recent discussion made it clear that the docs needed a sharper distinction between:
1. **software simulation of BB84-style note families**, and
2. **physical execution on quantum hardware**

Without that distinction, readers could incorrectly infer that the current QMoney baseline is closer to deployable quantum hardware than it actually is.

## Result
The docs now make the architecture boundary much more obvious:
- current baseline = **classical BB84-style simulator**
- future deployment = **real quantum hardware with logical-qubit and noise/loss constraints**
