### PR TITLE
docs: clarify qmoney threat model boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # QMoney: A Peer-to-Peer Quantum Money System
 
-The idea of quantum money has been around since the 70s-80s. It is the right time to revisit and turn it into an alternative form of freedom money. Ideally, QMoney (quantum money implementation suggested here) serves like the other side of Bitcoin (i.e., yin and yang). As Bitcoin security being weaker compared to current quantum computing technology development, QMoney becomes stronger because it is more feasible to implement QMoney as more logical qubits are avaiable to daily users.
+Quantum money has been studied since the late 1960s and early 1980s. QMoney revisits that line of work as a research program: can quantum no-cloning become an anti-counterfeiting layer for future cash-like systems while classical cryptographic ledgers handle ownership, settlement, and finality?
 
-QMoney is a _work-in-progress_ research repo for "distributed private-key quantum cash" inspired by:
+This repository is **not** a production currency, token, wallet, or hardware implementation. It is a _work-in-progress_ simulator and architecture workspace for "distributed private-key quantum cash" inspired by:
 
 - **[Stephen Wiesner](https://scottaaronson.blog/?p=5730) / [Peter Shor](https://math.mit.edu/~shor/)'s quantum money ideas**: unclonable quantum states, hidden verification data, and the distinction between private-key and public-key quantum money
 - **[Scott Aaronson / Paul Christiano](https://www.scottaaronson.com/papers/moneyfull.pdf)'s private-key quantum money ideas**: adaptive-query security, compact-secret tradeoffs, mini-scheme vs full-scheme thinking, and the importance of rigorous verifier models
@@ -183,7 +183,7 @@ This repo is a research and simulation workspace for:
 Near-term value here is primarily:
 - conceptual clarity
 - simulator design
-- attack modeling
+- attack modeling and private-key quorum threat modeling
 - note-family comparison
 - architecture documentation
 
@@ -197,6 +197,7 @@ not near-term deployment of production quantum money.
 - [`docs/architecture/public-vs-private-key-qmoney.md`](docs/architecture/public-vs-private-key-qmoney.md) — canonical statement of the current repo architecture and why QMoney is private-key quantum cash rather than public-key quantum money.
 - [`docs/architecture/software-mps-quorum-design.md`](docs/architecture/software-mps-quorum-design.md) — preserved technical appendix for the current software-only MPS/quorum baseline, including data model, protocol flow, simulation assumptions, and security intuition.
 - [`docs/architecture/classical-simulation-hardware-breakdown.md`](docs/architecture/classical-simulation-hardware-breakdown.md) — RAM/VRAM breakdown for MPS, sparse state-vector, and BB84 symbolic simulation approaches.
+- [`docs/architecture/private-key-quorum-threat-model.md`](docs/architecture/private-key-quorum-threat-model.md) — first-pass threat model for the current private-key quorum baseline, including adversary classes, quorum semantics, remint failure modes, and noise/tolerance questions.
 - [`docs/architecture/public-key-implementation-workflow.md`](docs/architecture/public-key-implementation-workflow.md) — implementation source of truth for AI agents and human implementers extending the public-key/oracle track in any language.
 
 ### Research notes

--- a/docs/architecture/private-key-quorum-threat-model.md
+++ b/docs/architecture/private-key-quorum-threat-model.md
@@ -1,0 +1,225 @@
+# Private-Key Quorum Threat Model
+
+> **Status:** first-pass architecture checklist for the current `pkey_quorum/` baseline. This document describes what the current simulator models, what it does not yet model, and which security questions should be answered before QMoney is described as anything more than research software.
+
+## Purpose
+
+QMoney's current implemented baseline is **distributed private-key quantum cash**:
+
+- the note family is BB84/Wiesner-like and private-key;
+- a verifier quorum holds hidden basis/bit verification material;
+- verification consumes the presented note;
+- a successful transfer remints a fresh note for the receiver;
+- a classical ledger records ownership and spent serials.
+
+That architecture is coherent, but it is not automatically trustless, public-key, or production-ready. This threat model keeps the near-term engineering path honest by naming the assumptions that still need to be implemented, measured, or formalized.
+
+## Current simulator scope
+
+The current `pkey_quorum/demo.py` simulator models:
+
+- symbolic BB84 product-state preparation;
+- hidden per-qubit basis/outcome secrets;
+- in-memory note ownership and spent-state tracking;
+- verifier availability through a `threshold` parameter;
+- consumptive measurement during verification;
+- verify-and-remint transfer semantics;
+- simple counterfeiting and adaptive-probe helpers.
+
+The current simulator does **not** yet model:
+
+- signed transfer-intent objects;
+- persistent, concurrent, or consensus-backed ledger state;
+- threshold secret sharing for verifier secrets;
+- Byzantine or colluding quorum members;
+- verifier attestation signatures;
+- atomic remint failure recovery;
+- hardware noise, loss, storage, transport, or custody;
+- a production public-key quantum verifier.
+
+## Assets and security goals
+
+### Assets
+
+- **Quantum note state:** the physical or simulated BB84-style state associated with a serial.
+- **Verifier secret:** hidden basis/outcome data needed to validate a serial.
+- **Serial lifecycle:** unspent/spent state and remint lineage.
+- **Ownership state:** the classical owner or claimant authorized to spend the note.
+- **Verifier attestations:** future signed statements that a quorum accepted or rejected a presented note.
+- **Remint randomness:** fresh basis/outcome data and serial generation for replacement notes.
+
+### Intended security goals
+
+1. A holder of one valid note should not be able to create two notes that both pass verification.
+2. A spent serial should not be accepted again.
+3. A valid transfer should either complete with a fresh replacement note or fail in a clearly recoverable state.
+4. A verifier request should not leak enough information to let an attacker reconstruct the hidden basis/outcome recipe.
+5. A minority of unavailable or faulty verifier nodes should not halt honest transfers if the configured quorum assumptions allow progress.
+6. A compromised verifier set below the defined compromise threshold should not be able to mint, validate, or leak arbitrary notes.
+
+The current code demonstrates only a subset of these goals. The rest are roadmap items.
+
+## Adversary classes
+
+### 1. Note-holder counterfeiter
+
+The attacker owns or temporarily obtains a valid note and tries to produce multiple notes that pass verification.
+
+Current coverage:
+
+- `counterfeit_intercept_resend(...)`
+- `one_note_to_two_counterfeit_trial(...)`
+
+Open work:
+
+- statistical test envelopes for expected counterfeit success rates;
+- tolerance/noise sensitivity curves;
+- multi-copy and copy-complexity experiments;
+- better mapping to Molina–Vidick–Watrous-style security games.
+
+### 2. Adaptive verifier-query attacker
+
+The attacker submits modified notes and learns from accept/reject behavior.
+
+Current coverage:
+
+- `adaptive_replacement_probe(...)` demonstrates that verifier interaction can leak information.
+
+Open work:
+
+- repeated-query strategies;
+- near-valid note probing;
+- basis-recovery experiments;
+- impact of tolerance on leakage;
+- limits on retries per serial or per ownership session.
+
+### 3. Malicious claimant or recipient
+
+The attacker tries to spend a note they do not own, replay a transfer, race a transfer, or exploit a remint failure.
+
+Current coverage:
+
+- `Ledger.owner_of(...)` and `Ledger.is_spent(...)` provide toy in-memory checks.
+
+Open work:
+
+- signed transfer-intent objects;
+- replay protection;
+- transaction IDs;
+- concurrent double-spend races;
+- recipient acknowledgement;
+- explicit failure states for consumed-but-not-reminted notes.
+
+### 4. Unavailable verifier nodes
+
+Some verifier nodes fail to participate.
+
+Current coverage:
+
+- `threshold` currently acts as a **minimum live-participant count**. If fewer nodes have the secret, verification does not start and the note remains live.
+
+Important caveat:
+
+- This is an availability model, not yet threshold secret sharing or Byzantine consensus.
+
+Open work:
+
+- distinguish availability quorum, voting quorum, and cryptographic threshold;
+- define liveness assumptions;
+- model partial verification attempts;
+- define who selects verifier participants.
+
+### 5. Compromised verifier nodes
+
+Some verifier nodes leak secrets, forge attestations, censor verification, or collude with counterfeiters.
+
+Current coverage:
+
+- not modeled beyond every `QuorumNode` storing the same full `BillSecret`.
+
+Open work:
+
+- threshold secret sharing or split verification data;
+- attestation signatures;
+- compromise thresholds;
+- accountability/slashing model if using a public network;
+- secret rotation and remint after suspected compromise;
+- tests for partial-secret leakage.
+
+### 6. Malicious or inconsistent ledger service
+
+The ledger records conflicting ownership or spent-state data.
+
+Current coverage:
+
+- in-memory `Ledger` object only.
+
+Open work:
+
+- persistence;
+- consensus/finality model;
+- atomic compare-and-set semantics for spending serials;
+- audit log of remint lineage;
+- recovery if verification and ledger update disagree.
+
+## Quorum semantics: current vs future
+
+The word **quorum** can mean several different things. QMoney should keep them separate.
+
+| Quorum meaning | Current simulator status | Future design question |
+| --- | --- | --- |
+| Availability quorum | Implemented: enough nodes must have the secret before verification starts | What liveness assumptions are acceptable? |
+| Voting/attestation quorum | Not implemented | Which signatures count as a final verification attestation? |
+| Threshold-secret quorum | Not implemented | Can verifier secrets be split so no single node knows the whole recipe? |
+| Byzantine quorum | Not implemented | How many malicious nodes can be tolerated? |
+| Remint authority quorum | Not implemented separately | Who is authorized to issue replacement notes? |
+
+Near-term docs and CLI help should describe the current code as an **availability-quorum simulator with replicated verifier secrets**, not as threshold cryptography.
+
+## Verify-and-remint failure modes
+
+The core transfer flow has four phases:
+
+1. present note and transfer intent;
+2. consume note by measurement;
+3. decide accept/reject;
+4. mint/register replacement note if accepted.
+
+Important failure cases to model next:
+
+- verification accepts but remint fails;
+- remint succeeds but ledger update fails;
+- ledger marks old note spent before replacement is durable;
+- two verifier groups race on the same serial;
+- claimant loses value because a note was consumed without a replacement path;
+- recipient receives a note that not all ledgers agree is live.
+
+A production design must make these states explicit. The simulator can start by adding a transfer-result object with enough detail to distinguish them.
+
+## Noise and tolerance questions
+
+The simulator exposes `noise_bitflip_p` and `tolerance`, but the security consequences are not yet characterized.
+
+Required analysis:
+
+- false accept probability for counterfeit notes as tolerance increases;
+- false reject probability for honest notes under noise;
+- how tolerance changes adaptive-query leakage;
+- whether mismatch counts should be revealed to users or only accept/reject;
+- how many failed attempts are allowed before a serial is locked or consumed.
+
+## Near-term implementation checklist
+
+Before QMoney claims anything stronger than a research simulator, Track A should add:
+
+1. direct API validation for note size, probability, basis, bit, and tolerance inputs;
+2. a signed transfer-intent data structure or at least a stubbed interface for one;
+3. a transfer-result object that records verification, spend, and remint outcomes;
+4. statistical counterfeit tests for small `n`;
+5. explicit docs/tests for availability quorum vs threshold-secret quorum;
+6. TLA+ lifecycle rules for spent serials, remint, and ownership transfer;
+7. a persistence/atomicity abstraction for `Ledger`.
+
+## Bottom line
+
+The current private-key quorum path is a strong research baseline because it is simple, honest, and close to Wiesner/BB84 intuition. Its next milestone is not public-key money. Its next milestone is a sharper **private-key quorum security model** that treats adaptive leakage, quorum compromise, remint atomicity, and noise/tolerance as first-class design questions.

--- a/website/README.md
+++ b/website/README.md
@@ -1,73 +1,65 @@
-# React + TypeScript + Vite
+# QMoney website
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This folder contains the Vite + React + TypeScript landing page for QMoney.
 
-Currently, two official plugins are available:
+The site is a public explanation layer for the repository. It should keep the same boundaries as the core docs:
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- QMoney is currently a **work-in-progress research project**, not a production token, wallet, or currency.
+- The implemented baseline is **distributed private-key quantum cash** with verify-and-remint semantics.
+- The public-key hidden-subspace path is a **research-only prototype** and not a deployable unforgeability claim.
+- Bitcoin is used as a settlement/finality reference point, not as a claim that QMoney is already “quantum Bitcoin.”
 
-## React Compiler
+## Local development
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+Install dependencies from this folder:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm ci
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Run the development server:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run dev
 ```
+
+Build the static site:
+
+```bash
+npm run build
+```
+
+Preview the production build:
+
+```bash
+npm run preview -- --host 127.0.0.1 --port 4173
+```
+
+## Verification
+
+Before committing website changes, run:
+
+```bash
+npm run build
+npm run lint
+npm run test
+```
+
+Current test coverage lives in `src/App.test.tsx` and checks the main messaging, reference links, theme behavior, and menu interactions.
+
+## Content rules
+
+When editing the website copy:
+
+1. Preserve the distinction between the private-key baseline and public-key research track.
+2. Avoid implying that the current repo implements production quantum hardware.
+3. Avoid implying that the hidden-subspace prototype is secure public-key quantum money.
+4. Keep “verify-and-remint” visible as the current transfer model.
+5. Link deeper claims back to the repository docs, especially:
+   - `docs/architecture/public-vs-private-key-qmoney.md`
+   - `docs/architecture/private-key-quorum-threat-model.md`
+   - `docs/research/latest-quantum-money-literature-and-qmoney.md`
+
+## Deployment note
+
+This is a static Vite site. `npm run build` writes output to `dist/`. The generated `dist/` directory is intentionally ignored by git.

--- a/website/src/App.test.tsx
+++ b/website/src/App.test.tsx
@@ -80,6 +80,11 @@ describe('App', () => {
       'href',
       'https://github.com/runeape-sats/qmoney/blob/main/docs/architecture/public-vs-private-key-qmoney.md',
     )
+    expect(screen.getByText(/threat model for the private-key quorum baseline/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /private-key quorum threat model/i })).toHaveAttribute(
+      'href',
+      'https://github.com/runeape-sats/qmoney/blob/main/docs/architecture/private-key-quorum-threat-model.md',
+    )
     expect(screen.getByRole('link', { name: /ekert quantum cryptography and qmoney/i })).toHaveAttribute(
       'href',
       'https://github.com/runeape-sats/qmoney/blob/main/docs/research/ekert-quantum-cryptography-and-qmoney.md',

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -40,6 +40,11 @@ const currentReferences = [
         description: 'Technical appendix for the current software-only MPS/quorum baseline and protocol flow.',
       },
       {
+        title: 'Private-key quorum threat model',
+        href: 'https://github.com/runeape-sats/qmoney/blob/main/docs/architecture/private-key-quorum-threat-model.md',
+        description: 'Threat model for the private-key quorum baseline, including adversaries, quorum assumptions, remint failure modes, and noise/tolerance questions.',
+      },
+      {
         title: 'Public-key implementation workflow',
         href: 'https://github.com/runeape-sats/qmoney/blob/main/docs/architecture/public-key-implementation-workflow.md',
         description: 'Implementation source of truth for the future public-key/oracle track.',


### PR DESCRIPTION
## Summary
- soften the README opening to frame QMoney as a research/simulator workspace rather than near-term production/freedom-money infrastructure
- add a first-pass private-key quorum threat model covering adversaries, quorum semantics, remint failure modes, and noise/tolerance questions
- replace the Vite template website README with QMoney-specific development, verification, and content-boundary guidance